### PR TITLE
Adds PAN-OS collection and prerequisites

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ aiokafka
 watchdog
 dpath
 aiobotocore
+pan-os-python
+xmltodict

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,5 +1,8 @@
 ---
 collections:
+  - name: paloaltonetworks.panos
+    version: ">=2.16.0,<3.0.0"
+    type: galaxy
   - name: "ansible.eda"
   - source: "."
     type: "dir"


### PR DESCRIPTION
Adds PAN-OS collection and prerequisites to the EDA container's environment

Tested locally with `invoke build`, `invoke local`